### PR TITLE
setting martyConnected to mv2.isConnected instead of false

### DIFF
--- a/src/editor/ScratchJr.js
+++ b/src/editor/ScratchJr.js
@@ -200,7 +200,7 @@ export default class ScratchJr {
         currentProject = urlvars.pmd5;
         editmode = urlvars.mode;
         martymode = false;
-        martyConnected = false;
+        martyConnected = mv2.isConnected;
         mv2.addEventListener('onIsConnectedChange', ScratchJr.onMartyConnectedChange);
 
         libInit();


### PR DESCRIPTION
BUG: 

If you have connected to your robot via connect screen then enter MartyBlocks Jr you have to connect again even though it says you are connected.

SOLUTION:
martyConnected global variable was set to _false_ when initialising a project. Now, it's set to _mv2.isConnected_  which is the actual state of connection.

[Jira ticket](https://robotical.atlassian.net/browse/BUGS-296)

